### PR TITLE
Fix bug in the creation of the parameter inheritance tree

### DIFF
--- a/src/AttributeParser.php
+++ b/src/AttributeParser.php
@@ -274,7 +274,7 @@ class AttributeParser
         foreach ($this->classAncestors($subject->getDeclaringClass()->name) as $class) {
             $rClass = new \ReflectionClass($class);
             if ($rClass->hasMethod($methodName)) {
-                $rMethod = $rClass->getMethod($parameterName);
+                $rMethod = $rClass->getMethod($methodName);
                 foreach ($rMethod->getParameters() as $rParam) {
                     if ($rParam->name === $parameterName) {
                         yield $rParam;


### PR DESCRIPTION
## Description

We should use the variable that holds the method name instead of the parameter name to get the method from the reflection class.

## Motivation and context

It's late, and I'm a bit tired, but I was just browsing the code and if I'm not mistaken, the wrong variable was used when getting the method while determining the parameter inheritance tree.

## How has this been tested?

I didn't.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
