### PR TITLE
Fix Testing section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,7 +795,7 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed re
 ## Testing
 
 ``` bash
-$ vendor/bin/phpunit
+$ composer test
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -795,7 +795,7 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed re
 ## Testing
 
 ``` bash
-$ composer test
+$ vendor/bin/phpunit
 ```
 
 ## Contributing

--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,9 @@
     },
     "scripts": {
         "phpstan": "vendor/bin/phpstan",
+        "test": "vendor/bin/phpunit",
         "all-checks": [
-            "phpunit",
+            "@test",
             "@phpstan"
         ],
         "benchmarks": "vendor/bin/phpbench run benchmarks --report=aggregate"


### PR DESCRIPTION
The Testing section referred to a non-existing composer script `test`