### PR TITLE
Fix PHP namespace imports

### DIFF
--- a/benchmarks/ClassAnalyzerBench.php
+++ b/benchmarks/ClassAnalyzerBench.php
@@ -25,6 +25,7 @@ use PhpBench\Benchmark\Metadata\Annotations\AfterMethods;
 use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
 use PhpBench\Benchmark\Metadata\Annotations\Iterations;
 use PhpBench\Benchmark\Metadata\Annotations\OutputTimeUnit;
+use PhpBench\Benchmark\Metadata\Annotations\RetryThreshold;
 use PhpBench\Benchmark\Metadata\Annotations\Revs;
 use PhpBench\Benchmark\Metadata\Annotations\Warmup;
 

--- a/src/AttributeParser.php
+++ b/src/AttributeParser.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Crell\AttributeUtils;
 
 use function Crell\fp\afilter;
-use function Crell\fp\all;
 use function Crell\fp\amap;
 use function Crell\fp\firstValue;
 use function Crell\fp\method;


### PR DESCRIPTION
Adds a missing `use` statement for the `RetryThreshold` annotation in `ClassAnalyzerBench` and removes an unused `use` statement from `AttributeParser