### PR TITLE
Add support for sub-attribute callbacks as closures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `AttributeUtils` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## 1.2.0 - FUTURE
+
+### Added
+- Sub-attribute callbacks may now be closures.  No need to reference methods by string anymore.
+
 ## 1.1.0 - 2024-02-24
 
 ### Added

--- a/src/HasSubAttributes.php
+++ b/src/HasSubAttributes.php
@@ -18,7 +18,7 @@ namespace Crell\AttributeUtils;
 interface HasSubAttributes
 {
     /**
-     * @return array<string, string>
+     * @return array<string, string|\Closure>
      *   A mapping of attribute class name to the callback method that should be called with it.
      */
     public function subAttributes(): array;

--- a/src/ReflectionDefinitionBuilder.php
+++ b/src/ReflectionDefinitionBuilder.php
@@ -135,14 +135,22 @@ class ReflectionDefinitionBuilder
                         }
                         $this->loadSubAttributes($sub, $reflection);
                     }
-                    $attribute->$callback($subs);
+                    if ($callback instanceof \Closure) {
+                        $callback($subs);
+                    } else {
+                        $attribute->$callback($subs);
+                    }
                 } else {
                     $sub = $this->parser->getInheritedAttribute($reflection, $type);
                     if ($sub instanceof Finalizable) {
                         $sub->finalize();
                     }
                     $this->loadSubAttributes($sub, $reflection);
-                    $attribute->$callback($sub);
+                    if ($callback instanceof \Closure) {
+                        $callback($sub);
+                    } else {
+                        $attribute->$callback($sub);
+                    }
                 }
             }
         }

--- a/tests/Attributes/ClosureSubAttributeInline.php
+++ b/tests/Attributes/ClosureSubAttributeInline.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\AttributeUtils\Attributes;
+
+#[\Attribute]
+class ClosureSubAttributeInline
+{
+    public function __construct(public string $b) {}
+}

--- a/tests/Attributes/ClosureSubAttributeMain.php
+++ b/tests/Attributes/ClosureSubAttributeMain.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\AttributeUtils\Attributes;
+
+use Crell\AttributeUtils\HasSubAttributes;
+
+#[\Attribute]
+class ClosureSubAttributeMain implements HasSubAttributes
+{
+    public readonly ?ClosureSubAttributeReferenced $referenced;
+    public readonly ?ClosureSubAttributeInline $inline;
+
+    public function subAttributes(): array
+    {
+        return [
+            ClosureSubAttributeReferenced::class => $this->fromReferenced(...),
+            ClosureSubAttributeInline::class => function(?ClosureSubAttributeInline $other) {
+                $this->inline = $other;
+            }
+        ];
+    }
+
+    private function fromReferenced(?ClosureSubAttributeReferenced $other): void
+    {
+        $this->referenced ??= $other;
+    }
+}

--- a/tests/Attributes/ClosureSubAttributeReferenced.php
+++ b/tests/Attributes/ClosureSubAttributeReferenced.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\AttributeUtils\Attributes;
+
+#[\Attribute]
+class ClosureSubAttributeReferenced
+{
+    public function __construct(public string $a) {}
+}

--- a/tests/ClassAnalyzerTest.php
+++ b/tests/ClassAnalyzerTest.php
@@ -14,6 +14,7 @@ use Crell\AttributeUtils\Attributes\ClassWithProperties;
 use Crell\AttributeUtils\Attributes\ClassWithPropertiesWithSubAttributes;
 use Crell\AttributeUtils\Attributes\ClassWithReflection;
 use Crell\AttributeUtils\Attributes\ClassWithSubSubAttributes;
+use Crell\AttributeUtils\Attributes\ClosureSubAttributeMain;
 use Crell\AttributeUtils\Attributes\FinalizableClassAttribute;
 use Crell\AttributeUtils\Attributes\GenericClass;
 use Crell\AttributeUtils\Attributes\Labeled;
@@ -34,6 +35,7 @@ use Crell\AttributeUtils\InterfaceAttributes\Hero;
 use Crell\AttributeUtils\InterfaceAttributes\Name;
 use Crell\AttributeUtils\InterfaceAttributes\Names;
 use Crell\AttributeUtils\Records\AttributesInheritChild;
+use Crell\AttributeUtils\Records\ClassWithClosureSubAttributes;
 use Crell\AttributeUtils\Records\ClassWithConstantsChild;
 use Crell\AttributeUtils\Records\ClassWithCustomizedFields;
 use Crell\AttributeUtils\Records\ClassWithCustomizedPropertiesExcludeByDefault;
@@ -406,6 +408,15 @@ class ClassAnalyzerTest extends TestCase
             'test' => static function (FinalizableClassAttribute $classDef) {
                 self::assertTrue($classDef->wasFinalized);
                 self::assertTrue($classDef->properties['foo']->greater);
+            },
+        ];
+
+        yield 'Closures work as sub-attribute callbacks' => [
+            'subject' => ClassWithClosureSubAttributes::class,
+            'attribute' => ClosureSubAttributeMain::class,
+            'test' => static function (ClosureSubAttributeMain $classDef) {
+                self::assertEquals('A', $classDef->referenced->a);
+                self::assertEquals('B', $classDef->inline->b);
             },
         ];
     }

--- a/tests/Records/ClassWithClosureSubAttributes.php
+++ b/tests/Records/ClassWithClosureSubAttributes.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\AttributeUtils\Records;
+
+use Crell\AttributeUtils\Attributes\ClosureSubAttributeInline;
+use Crell\AttributeUtils\Attributes\ClosureSubAttributeMain;
+use Crell\AttributeUtils\Attributes\ClosureSubAttributeReferenced;
+
+#[ClosureSubAttributeMain]
+#[ClosureSubAttributeReferenced('A')]
+#[ClosureSubAttributeInline('B')]
+class ClassWithClosureSubAttributes
+{
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allows the `subAttributes()` method to return a callback as a closure, rather than a method name string.

## Motivation and context

Code in strings is awful.

## How has this been tested?

New tests included.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
