### PR TITLE
Allow class inheritance determination for enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,54 @@ In this case, a class may be marked with either `Screen` or `Audio`, but not bot
 
 In this example, `$displayInfoA->type` will be an instance of `Screen`, `$displayInfoB->type` will be an instance of `Audio`, and `$displayInfoC->type` will be `null`.
 
+### Interface using attributes
+
+Interfaces may also implement attributes. This is useful for cases in which you want to define a type map at the interface level.
+
+Note: in this case, make sure the class implements the `Inheritable` interface, to return the expected values.
+
+```php
+use Crell\AttributeUtils\Inheritable;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Application implements Inheritable
+{
+    public function __construct(
+        public readonly string $name,
+    ) {
+    }
+}
+
+#[Application(name: 'app')]
+interface Something
+{
+}
+
+enum MyEnum: string implements Something
+{
+    case A = 'a';
+    case B = 'b';
+}
+
+#[Application(name: 'other-app')]
+enum AnotherEnum: string implements Something
+{
+    case A = 'a';
+    case B = 'b';
+}
+
+
+$analyzer = new Crell\AttributeUtils\Analyzer();
+
+/** @var Application $anotherEnumAttributes */
+$enumAttributes = $analyzer->analyze(MyEnum::class, Application::class);
+print $enumAttributes->name . PHP_EOL; // Prints 'app'
+
+/** @var Application $classAttributes */
+$anotherEnumAttributes = $analyzer->analyze(AnotherEnum::class, Application::class);
+print $anotherEnumAttributes->name . PHP_EOL; // Prints 'other-app'
+```
+
 ## Change log
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.

--- a/README.md
+++ b/README.md
@@ -822,7 +822,7 @@ In this example, `$displayInfoA->type` will be an instance of `Screen`, `$displa
 
 Interfaces may also implement attributes. This is useful for cases in which you want to define a type map at the interface level.
 
-Note: in this case, make sure the class implements the `Inheritable` interface, to return the expected values.
+Note: in this case, make sure the attribute class implements the `Inheritable` interface, so that implementing classes can inherit it.
 
 ```php
 use Crell\AttributeUtils\Inheritable;

--- a/src/AttributeParser.php
+++ b/src/AttributeParser.php
@@ -224,8 +224,7 @@ class AttributeParser
                 \ReflectionMethod::class => $this->classElementInheritanceTree($subject),
                 \ReflectionClassConstant::class => $this->classElementInheritanceTree($subject),
                 \ReflectionParameter::class => $this->parameterInheritanceTree($subject),
-                // If it's an enum, there's nothing to inherit so just stub that out.
-                \ReflectionEnum::class => [],
+                \ReflectionEnum::class => $this->classInheritanceTree($subject),
             };
         }
     }
@@ -235,7 +234,7 @@ class AttributeParser
      *
      * This includes both classes and interfaces.
      *
-     * @param \ReflectionClass<object> $subject
+     * @param \ReflectionClass<object>|\ReflectionEnum<\UnitEnum> $subject
      *   The reflection of the class for which we want the ancestors.
      * @return iterable<\ReflectionClass<object>>
      * @throws \ReflectionException

--- a/tests/ClassAnalyzerTest.php
+++ b/tests/ClassAnalyzerTest.php
@@ -49,6 +49,7 @@ use Crell\AttributeUtils\Records\ClassWithScopes;
 use Crell\AttributeUtils\Records\ClassWithScopesMulti;
 use Crell\AttributeUtils\Records\ClassWithScopesNotDefault;
 use Crell\AttributeUtils\Records\ClassWithSubAttributes;
+use Crell\AttributeUtils\Records\EnumWithInterface;
 use Crell\AttributeUtils\Records\LabeledApp;
 use Crell\AttributeUtils\Records\MissingPropertyAttributeArguments;
 use Crell\AttributeUtils\Records\MultiuseClass;
@@ -413,6 +414,15 @@ class ClassAnalyzerTest extends TestCase
             'attribute' => ClassWithOwnSubAttributes::class,
             'test' => static function(ClassWithOwnSubAttributes $classDef) {
                 self::assertEquals('C', $classDef->c);
+            },
+        ];
+
+        yield 'Enum implementing interface' => [
+            'subject' => EnumWithInterface::class,
+            'attribute' => BasicClass::class,
+            'test' => static function(mixed $classDef) {
+                self::assertEquals(5, $classDef->a);
+                self::assertEquals(10, $classDef->b);
             },
         ];
 

--- a/tests/Records/EnumWithInterface.php
+++ b/tests/Records/EnumWithInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\AttributeUtils\Records;
+
+enum EnumWithInterface: int implements AnInterface
+{
+    case A = 1;
+    case B = 2;
+}


### PR DESCRIPTION
## Description

Read enum implemented interfaces and its attributes

## Motivation and context

In the scope of [a downstream project issue](https://github.com/Crell/Serde/issues/10), It was noticed that in cases where an enum implemented an interface, the interface attributes could not be read.

This change allows `ReflectionEnum` to retrieve such information if it exists.

## How has this been tested?

Unit test case has been added to existing test

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

